### PR TITLE
Small fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         stages: [commit]
         name: api-black
         language: system
-        entry: /bin/sh -c 'cd ./api/ && black'
+        entry: /bin/sh -c 'cd ./api/ && black .'
         types: [python]
       - id: api-flake8
         stages: [commit]

--- a/api/mysagw/identity/factories.py
+++ b/api/mysagw/identity/factories.py
@@ -8,6 +8,7 @@ class IdentityFactory(DjangoModelFactory):
     idp_id = Faker("uuid4")
     email = Faker("email")
     is_organisation = False
+    organisation_name = None
 
     class Meta:
         model = models.Identity

--- a/api/mysagw/identity/serializers.py
+++ b/api/mysagw/identity/serializers.py
@@ -29,6 +29,7 @@ class EmailSerializer(SetModifyingUserOnIdentityMixin, serializers.ModelSerializ
 
     class Meta:
         model = models.Email
+        resource_name = "additional-emails"
         fields = (
             "email",
             "identity",

--- a/api/mysagw/identity/serializers.py
+++ b/api/mysagw/identity/serializers.py
@@ -69,11 +69,14 @@ class IdentitySerializer(TrackingSerializer):
             "email",
             "additional_emails",
             "phone_numbers",
+            "is_organisation",
+            "organisation_name",
         )
         extra_kwargs = {
             **TrackingSerializer.Meta.extra_kwargs,
             "interests": {"required": False},
             "email": {"read_only": True},
+            "idp_id": {"read_only": True},
             "additional_emails": {"required": False},
             "phone_numbers": {"required": False},
         }

--- a/api/mysagw/identity/tests/test_email_views.py
+++ b/api/mysagw/identity/tests/test_email_views.py
@@ -90,7 +90,7 @@ def test_email_create(db, identity, client, expected_status):
 
     data = {
         "data": {
-            "type": "emails",
+            "type": "additional-emails",
             "attributes": {"email": "test@example.com"},
             "relationships": {
                 "identity": {"data": {"id": str(identity.pk), "type": "identities"}},
@@ -119,7 +119,7 @@ def test_email_create_with_includes(db, email_factory, client):
 
     data = {
         "data": {
-            "type": "emails",
+            "type": "additional-emails",
             "attributes": {"email": "test@example.com"},
             "relationships": {
                 "identity": {
@@ -164,7 +164,7 @@ def test_email_update(db, client, expected_status, email_factory):
 
     data = {
         "data": {
-            "type": "emails",
+            "type": "additional-emails",
             "id": str(email.pk),
             "attributes": {"description": "Foo"},
         }

--- a/api/mysagw/identity/tests/test_identity_views.py
+++ b/api/mysagw/identity/tests/test_identity_views.py
@@ -68,7 +68,7 @@ def test_identity_list(db, client, expected_status):
 def test_identity_create(db, client, expected_status):
     url = reverse("identity-list")
 
-    data = {"data": {"type": "identities", "attributes": {"idp_id": "foo"}}}
+    data = {"data": {"type": "identities", "attributes": {"first_name": "foo"}}}
 
     response = client.post(url, data=data)
 
@@ -77,7 +77,7 @@ def test_identity_create(db, client, expected_status):
     if expected_status == status.HTTP_403_FORBIDDEN:
         return
 
-    identity = Identity.objects.get(idp_id="foo")
+    identity = Identity.objects.get(first_name="foo")
     assert identity.created_by_user == identity.modified_by_user == client.user.username
     json = response.json()
     assert (

--- a/api/mysagw/oidc_auth/models.py
+++ b/api/mysagw/oidc_auth/models.py
@@ -63,6 +63,8 @@ class OIDCUser(BaseUser):
             identity = Identity.objects.create(
                 idp_id=self.id,
                 email=self.username,
+                modified_by_user=self.username,
+                created_by_user=self.username,
             )
         return identity
 


### PR DESCRIPTION
**fix(api): fix IdentitySerializer**

This commit makes following changes to the IdentitySerializer:
 - add field `is_organisation`
 - add field `organisation_name`
 - make idp_id read_only

**chore: fix black pre-commit-hook**

**chore(api): ignore InsecureRequestWarning in dev**

**fix(api): fix additional-emails resource_name**

**fix(api): set modified and created on identity creation**

**fix(api): add validation for setting "is_organisation"**