### PR TITLE
fix(ember): show identity search term if present

### DIFF
--- a/ember/app/ui/identities/index/template.hbs
+++ b/ember/app/ui/identities/index/template.hbs
@@ -11,6 +11,7 @@
     <input
       class="uk-input"
       id="form-search"
+      value={{this.searchTerm}}
       {{on "input" (perform this.search)}}
     >
   </div>


### PR DESCRIPTION
As the controller instance is kept around when navigating to other
routes the search term is still present when returning but not shown
in the search form. This show the term in the form.