### PR TITLE
feat(ember): improve responsive layout for identities list

### DIFF
--- a/ember/app/ui/identities/index/template.hbs
+++ b/ember/app/ui/identities/index/template.hbs
@@ -42,7 +42,7 @@
                 </div>
               {{/if}}
 
-              <div class="uk-text-small">
+              <div class="uk-text-small uk-width-1-1 uk-width-auto@s">
                 {{identity.email}}
               </div>
             </LinkTo>


### PR DESCRIPTION
This change forces all email addresses below the names for mobile
views and only wraps single addresses if the name or address are
too long.