### PR TITLE
fix(ember): update dirty-state of identity email field

### DIFF
--- a/ember/app/ui/components/identity-form/template.hbs
+++ b/ember/app/ui/components/identity-form/template.hbs
@@ -55,6 +55,7 @@
               disabled={{this.changeset.idpId}}
               value={{field.value}}
               {{on "input" (fn this.eventTarget field.update)}}
+              {{on "blur" field.setDirty}}
             >
           </div>
           {{#if this.changeset.idpId}}


### PR DESCRIPTION
Otherwise, it looks broken when compared to the other fields that
become green after having received (and lost) focus.