### PR TITLE
fix(ember): remove obsolete translations

### DIFF
--- a/ember/translations/en.yaml
+++ b/ember/translations/en.yaml
@@ -173,13 +173,11 @@ component:
     add: "Add interest"
 
     list:
-      edit: "Edit interest"
       delete: "Delete interest"
       empty: "No interests yet."
     form:
       title:
         add: "Add interest"
-        edit: "Edit interest"
       label:
         interest: "Interest"
       control:


### PR DESCRIPTION
I forgot to remove them when I removed the accociated functionality.