### PR TITLE
fix(ember): set correct key in translation options

### DIFF
--- a/ember/app/ui/components/identity-phone-numbers/component.js
+++ b/ember/app/ui/components/identity-phone-numbers/component.js
@@ -81,7 +81,7 @@ export default class IdentityPhoneNumbersComponent extends Component {
 
   @dropTask *delete(phoneNumber) {
     try {
-      const options = { address: phoneNumber.phone };
+      const options = { number: phoneNumber.phone };
       yield UIkit.modal.confirm(
         this.intl.t("component.identity-phone-numbers.delete.prompt", options)
       );


### PR DESCRIPTION
This is an artifact from copy/pasting the email address component.