### PR TITLE
chore: update keycloak config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       "-Dkeycloak.migration.action=import",
       "-Dkeycloak.migration.strategy=IGNORE_EXISTING",
       "-Dkeycloak.migration.provider=singleFile",
-      "-Dkeycloak.migration.file=/etc/keycloak/dev-config.json",
+      "-Dkeycloak.migration.file=/etc/keycloak/config.json",
       "-b",
       "0.0.0.0",
       ]

--- a/keycloak/config.json
+++ b/keycloak/config.json
@@ -377,7 +377,17 @@
       "path": "/admin",
       "attributes": {},
       "realmRoles": [],
-      "clientRoles": {},
+      "clientRoles": {
+        "realm-management": [
+          "manage-authorization",
+          "query-users",
+          "impersonation",
+          "view-users",
+          "view-authorization",
+          "query-groups",
+          "manage-users"
+        ]
+      },
       "subGroups": []
     },
     {
@@ -645,8 +655,8 @@
         "http://mysagw.local:4200/*"
       ],
       "webOrigins": [
-        "https://mysagw.local",
-        "http://mysagw.local:4200"
+        "http://mysagw.local:4200",
+        "https://mysagw.local"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -906,6 +916,7 @@
           "consentRequired": false,
           "config": {
             "multivalued": "true",
+            "userinfo.token.claim": "true",
             "user.attribute": "foo",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -2109,7 +2120,12 @@
   "resetCredentialsFlow": "reset credentials",
   "clientAuthenticationFlow": "clients",
   "dockerAuthenticationFlow": "docker auth",
-  "attributes": {},
-  "keycloakVersion": "12.0.1",
+  "attributes": {
+    "clientOfflineSessionMaxLifespan": "0",
+    "clientSessionIdleTimeout": "0",
+    "clientSessionMaxLifespan": "0",
+    "clientOfflineSessionIdleTimeout": "0"
+  },
+  "keycloakVersion": "12.0.4",
   "userManagedAccessAllowed": false
 }


### PR DESCRIPTION
This commit updates the keycloak config. Users in the `admin` group now
have permission to manage users and groups.

Additionally the keycloak config file lost its `dev-` prefix, as it's
also used in prod.