### PR TITLE
fix(ember): add fallback to empty object for timeSlot

### DIFF
--- a/ember/app/ui/components/identity-memberships/component.js
+++ b/ember/app/ui/components/identity-memberships/component.js
@@ -53,6 +53,10 @@ export default class IdentityMembershipsComponent extends Component {
       lookupValidator(MembershipValidations),
       MembershipValidations
     );
+
+    if (!this.changeset.get("timeSlot")) {
+      this.changeset.set("timeSlot", {});
+    }
   }
 
   @action cancel() {


### PR DESCRIPTION
If no timeSlot is set the backend returns null. But Changeset then
fails because it want's to set a property of null.