### PR TITLE
fix(ember): disable secure-proxy for the start-dev NPM run-script.

### DIFF
--- a/ember/package.json
+++ b/ember/package.json
@@ -16,7 +16,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "start-proxy": "ember server --proxy=https://mysagw.local",
+    "start-proxy": "ember server --proxy=https://mysagw.local --secure-proxy=false",
     "test": "npm-run-all lint:* test:*",
     "test:ember": "ember test"
   },


### PR DESCRIPTION
Otherwise, the dev-server will fail when proxying from HTTP to HTTPS.