### PR TITLE
fix(ember): disallow removing the default flag from phone numbers

### DIFF
--- a/ember/app/ui/components/identity-phone-numbers/template.hbs
+++ b/ember/app/ui/components/identity-phone-numbers/template.hbs
@@ -53,7 +53,7 @@
                   class="uk-icon-button uk-button-default"
                   type="button"
                   uk-icon="close"
-                  disabled={{or this.changeset this.delete.isRunning}}
+                  disabled={{or this.changeset this.delete.isRunning phoneNumber.default}}
                   title={{t "component.identity-phone-numbers.list.delete"}}
                   {{on "click" (perform this.delete phoneNumber)}}
                 ></button>
@@ -111,6 +111,7 @@
         @type="checkbox"
         @name="default"
         @required={{false}}
+        @disabled={{this.changeset.default}}
       />
 
       <p class="uk-text-right">


### PR DESCRIPTION
If there is at least a phone number one must be set as default.