### PR TITLE
fix(ember): update error handling for forms

### DIFF
--- a/ember/app/ui/components/identity-phone-numbers/component.js
+++ b/ember/app/ui/components/identity-phone-numbers/component.js
@@ -71,6 +71,15 @@ export default class IdentityPhoneNumbersComponent extends Component {
       this.onUpdate();
       this.changeset = null;
     } catch (error) {
+      // A "unique" error can only apply to the phone number.
+      // But as the backend validation doesn't stem from the field itself
+      // it cannot automatically be attributed by `applyError`. That's why we add
+      // the specific field error manually to the changeset if present.
+      const unique = error.errors?.find(({ code }) => code === "unique");
+      if (unique) {
+        changeset.addError("phone", unique.detail);
+      }
+
       console.error(error);
       this.notification.fromError(error);
       applyError(changeset, error);

--- a/ember/app/utils/apply-error.js
+++ b/ember/app/utils/apply-error.js
@@ -1,6 +1,10 @@
 export default function applyError(changeset, error) {
   error.errors
-    .filter(({ source: { pointer } }) => pointer.startsWith("/data/attributes"))
+    .filter(
+      ({ source: { pointer } }) =>
+        pointer.startsWith("/data/attributes") &&
+        !pointer.endsWith("non-field-errors")
+    )
     .map(({ detail, source: { pointer } }) => ({
       field: pointer.substr(pointer.lastIndexOf("/") + 1),
       message: detail,


### PR DESCRIPTION
Add unique handling for phone-numbers and ignore "non-field-errors" in
the utility function.