### PR TITLE
fix(ember): restrict isOrganisation option in form

### DIFF
--- a/ember/app/models/identity.js
+++ b/ember/app/models/identity.js
@@ -11,6 +11,8 @@ export default class IdentityModel extends LocalizedModel {
   @hasMany phoneNumbers;
   @hasMany interests;
   @attr isOrganisation;
+  @attr hasMemberships;
+  @attr hasMembers;
 
   get fullName() {
     return [this.firstName, this.lastName].filter(Boolean).join(" ");

--- a/ember/app/ui/components/identity-form/template.hbs
+++ b/ember/app/ui/components/identity-form/template.hbs
@@ -14,6 +14,10 @@
         @type="checkbox"
         @name="isOrganisation"
         @on-update={{this.updateOrganisation}}
+        @disabled={{or
+          this.changeset.hasMembers
+          this.changeset.hasMemberships
+        }}
       />
 
       {{#if this.changeset.isOrganisation}}


### PR DESCRIPTION
Don't allow setting isOrganisation if it is already member of an
organisation. Don't allor removing isOrganisation if the organisation
has members assigned.