### PR TITLE
feat(ember): introduce email-only export

### DIFF
--- a/api/mysagw/identity/views.py
+++ b/api/mysagw/identity/views.py
@@ -91,7 +91,7 @@ class IdentityViewSet(views.ModelViewSet):
         response = django_excel.make_response_from_records(records, "xlsx")
         return response
 
-    @action(detail=False, methods=["post"])
+    @action(detail=False, methods=["post"], url_path="export-email")
     def export_email(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
 

--- a/ember/app/ui/identities/index/controller.js
+++ b/ember/app/ui/identities/index/controller.js
@@ -61,12 +61,12 @@ export default class IdentitiesIndexController extends Controller {
     this.fetchIdentities.perform();
   }
 
-  @dropTask *exportSearch() {
+  @dropTask *exportSearch(endpoint) {
     const adapter = this.store.adapterFor("identity");
 
     let uri = `${this.store
       .adapterFor("identity")
-      .buildURL("identity")}/export`;
+      .buildURL("identity")}/${endpoint}`;
 
     if (this.searchTerm) {
       uri += `?filter[search]=${this.searchTerm}`;

--- a/ember/app/ui/identities/index/template.hbs
+++ b/ember/app/ui/identities/index/template.hbs
@@ -7,14 +7,29 @@
 
     {{#if (can "add identity")}}
       <div class="uk-flex-none">
-        <button
-          type="button"
-          class="uk-button uk-button-primary"
-          disabled={{this.exportSearch.isRunning}}
-          {{on "click" (perform this.exportSearch)}}
-        >
-          {{t "page.identities.index.export.button"}}
-        </button>
+        <div class="uk-inline">
+          <button
+            type="button"
+            class="uk-button uk-button-primary"
+          >
+            {{t "page.identities.index.export.button"}}
+            <span uk-icon="triangle-down"></span>
+          </button>
+          <div uk-dropdown="mode: click">
+            <ul class="uk-nav uk-dropdown-nav">
+              <li>
+                <a href="#" {{on "click" (perform this.exportSearch "export")}}>
+                  {{t "page.identities.index.export.standard"}}
+                </a>
+              </li>
+              <li>
+                <a href="#" {{on "click" (perform this.exportSearch "export-email")}}>
+                  {{t "page.identities.index.export.email-only"}}
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
 
         <LinkTo
           @route="identities.add"

--- a/ember/translations/en.yaml
+++ b/ember/translations/en.yaml
@@ -69,6 +69,8 @@ page:
       add: "Add identity"
       export:
         button: "Export"
+        standard: "Standard"
+        email-only: "Email only"
         filename: "identities-{date}"
       search: "Search"
 


### PR DESCRIPTION
This commit an export dropdown instead of button for offering all the
available export types. In this dropdown, the standard export and an
email-only export is available.

Additionally, this commit changes the email export uri path from the api
from `export_email` to `export-email`.