### PR TITLE
feat(api): let users manage their own data

### DIFF
--- a/api/mysagw/identity/permissions.py
+++ b/api/mysagw/identity/permissions.py
@@ -31,3 +31,14 @@ class IsOrgAdmin(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return obj in request.user.identity.authorized_for
+
+
+class IsOwnOrAuthorized(BasePermission):
+    def has_permission(self, request, view):
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return getattr(obj, "identity") and (
+            obj.identity == request.user.identity
+            or obj.identity in request.user.identity.authorized_for
+        )


### PR DESCRIPTION
This commit opens the endpoints for emails, phone_numbers and addresses,
so that users can manage their own data and the data they're authorized
to manage.