### PR TITLE
feat(api): let users read their own memberships

### DIFF
--- a/api/mysagw/identity/filters.py
+++ b/api/mysagw/identity/filters.py
@@ -40,4 +40,5 @@ class MembershipFilterSet(FilterSet):
         model = models.Membership
         fields = [
             "identity",
+            "authorized",
         ]

--- a/api/mysagw/identity/permissions.py
+++ b/api/mysagw/identity/permissions.py
@@ -25,20 +25,14 @@ class IsStaff(BasePermission):
         return self.has_permission(request, view)
 
 
-class IsOrgAdmin(BasePermission):
-    def has_permission(self, request, view):
-        return True
-
+class IsAuthorized(BasePermission):
     def has_object_permission(self, request, view, obj):
-        return obj in request.user.identity.authorized_for
-
-
-class IsOwnOrAuthorized(BasePermission):
-    def has_permission(self, request, view):
-        return True
-
-    def has_object_permission(self, request, view, obj):
-        return getattr(obj, "identity") and (
-            obj.identity == request.user.identity
-            or obj.identity in request.user.identity.authorized_for
+        return obj in request.user.identity.authorized_for or (
+            hasattr(obj, "identity")
+            and (obj.identity in request.user.identity.authorized_for)
         )
+
+
+class IsOwn(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        return hasattr(obj, "identity") and (obj.identity == request.user.identity)

--- a/api/mysagw/identity/permissions.py
+++ b/api/mysagw/identity/permissions.py
@@ -1,9 +1,17 @@
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 
 class IsAuthenticated(BasePermission):
     def has_permission(self, request, view):
         return bool(request.user and request.user.is_authenticated)
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+
+class ReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        return bool(request.method in SAFE_METHODS)
 
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view)

--- a/api/mysagw/identity/tests/test_address_views.py
+++ b/api/mysagw/identity/tests/test_address_views.py
@@ -10,8 +10,8 @@ from mysagw.identity import models
     [
         ("user", False, status.HTTP_404_NOT_FOUND),
         ("user", True, status.HTTP_200_OK),
-        ("staff", True, status.HTTP_200_OK),
-        ("admin", True, status.HTTP_200_OK),
+        ("staff", False, status.HTTP_200_OK),
+        ("admin", False, status.HTTP_200_OK),
     ],
     indirect=["client"],
 )
@@ -61,8 +61,8 @@ def test_address_list(db, client, expected_count, address_factory):
     [
         ("user", False, status.HTTP_403_FORBIDDEN),
         ("user", True, status.HTTP_201_CREATED),
-        ("staff", True, status.HTTP_201_CREATED),
-        ("admin", True, status.HTTP_201_CREATED),
+        ("staff", False, status.HTTP_201_CREATED),
+        ("admin", False, status.HTTP_201_CREATED),
     ],
     indirect=["client"],
 )
@@ -159,8 +159,8 @@ def test_address_create_new_default(db, address_factory, client):
     [
         ("user", False, status.HTTP_404_NOT_FOUND),
         ("user", True, status.HTTP_200_OK),
-        ("staff", True, status.HTTP_200_OK),
-        ("admin", True, status.HTTP_200_OK),
+        ("staff", False, status.HTTP_200_OK),
+        ("admin", False, status.HTTP_200_OK),
     ],
     indirect=["client"],
 )
@@ -208,8 +208,8 @@ def test_address_update(db, client, own, expected_status, address):
     [
         ("user", False, status.HTTP_404_NOT_FOUND),
         ("user", True, status.HTTP_204_NO_CONTENT),
-        ("staff", True, status.HTTP_204_NO_CONTENT),
-        ("admin", True, status.HTTP_204_NO_CONTENT),
+        ("staff", False, status.HTTP_204_NO_CONTENT),
+        ("admin", False, status.HTTP_204_NO_CONTENT),
     ],
     indirect=["client"],
 )

--- a/api/mysagw/identity/tests/test_phone_number_views.py
+++ b/api/mysagw/identity/tests/test_phone_number_views.py
@@ -10,8 +10,8 @@ from mysagw.identity import models
     [
         ("user", False, status.HTTP_404_NOT_FOUND),
         ("user", True, status.HTTP_200_OK),
-        ("staff", True, status.HTTP_200_OK),
-        ("admin", True, status.HTTP_200_OK),
+        ("staff", False, status.HTTP_200_OK),
+        ("admin", False, status.HTTP_200_OK),
     ],
     indirect=["client"],
 )
@@ -61,8 +61,8 @@ def test_phone_number_list(db, client, expected_count, phone_number_factory):
     [
         ("user", False, status.HTTP_403_FORBIDDEN),
         ("user", True, status.HTTP_201_CREATED),
-        ("staff", True, status.HTTP_201_CREATED),
-        ("admin", True, status.HTTP_201_CREATED),
+        ("staff", False, status.HTTP_201_CREATED),
+        ("admin", False, status.HTTP_201_CREATED),
     ],
     indirect=["client"],
 )
@@ -150,8 +150,8 @@ def test_phone_number_create_new_default(db, phone_number_factory, client):
     [
         ("user", False, status.HTTP_404_NOT_FOUND),
         ("user", True, status.HTTP_200_OK),
-        ("staff", True, status.HTTP_200_OK),
-        ("admin", True, status.HTTP_200_OK),
+        ("staff", False, status.HTTP_200_OK),
+        ("admin", False, status.HTTP_200_OK),
     ],
     indirect=["client"],
 )
@@ -221,8 +221,8 @@ def test_phone_number_update_unset_default(db, client, phone_number):
     [
         ("user", False, status.HTTP_404_NOT_FOUND),
         ("user", True, status.HTTP_204_NO_CONTENT),
-        ("staff", True, status.HTTP_204_NO_CONTENT),
-        ("admin", True, status.HTTP_204_NO_CONTENT),
+        ("staff", False, status.HTTP_204_NO_CONTENT),
+        ("admin", False, status.HTTP_204_NO_CONTENT),
     ],
     indirect=["client"],
 )

--- a/api/mysagw/identity/views.py
+++ b/api/mysagw/identity/views.py
@@ -8,13 +8,7 @@ from rest_framework_json_api import views
 
 from . import filters, models, serializers
 from .export import IdentityExport
-from .permissions import (
-    IsAdmin,
-    IsAuthenticated,
-    IsOrgAdmin,
-    IsOwnOrAuthorized,
-    IsStaff,
-)
+from .permissions import IsAdmin, IsAuthenticated, IsAuthorized, IsOwn, IsStaff
 
 
 class UniqueBooleanFieldViewSetMixin:
@@ -60,7 +54,7 @@ class IdentityAdditionsViewSetMixin:
 class EmailViewSet(IdentityAdditionsViewSetMixin, views.ModelViewSet):
     serializer_class = serializers.EmailSerializer
     queryset = models.Email.objects.all()
-    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | IsOwnOrAuthorized),)
+    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | IsOwn | IsAuthorized),)
     filterset_class = filters.EmailFilterSet
 
     def perform_destroy(self, instance):
@@ -74,7 +68,7 @@ class PhoneNumberViewSet(
 ):
     serializer_class = serializers.PhoneNumberSerializer
     queryset = models.PhoneNumber.objects.all()
-    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | IsOwnOrAuthorized),)
+    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | IsOwn | IsAuthorized),)
     filterset_class = filters.PhoneNumberFilterSet
 
     def perform_destroy(self, instance):
@@ -86,7 +80,7 @@ class PhoneNumberViewSet(
 class AddressViewSet(IdentityAdditionsViewSetMixin, views.ModelViewSet):
     serializer_class = serializers.AddressSerializer
     queryset = models.Address.objects.all()
-    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | IsOwnOrAuthorized),)
+    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | IsOwn | IsAuthorized),)
     filterset_class = filters.AddressFilterSet
 
     def perform_destroy(self, instance):
@@ -158,7 +152,7 @@ class MyOrgsViewSet(
     GenericViewSet,
 ):
     serializer_class = serializers.MyOrgsSerializer
-    permission_classes = (IsAuthenticated & IsOrgAdmin,)
+    permission_classes = (IsAuthenticated & IsAuthorized,)
 
     def get_queryset(self):
         return self.request.user.identity.member_of


### PR DESCRIPTION
Also add `authorized`-filter.

## Necessary refactoring:

**chore(api): refactor identity permissions**

This commit refactors the permissions for the email, phone and address
views. Additionally, it fixes the parametrisations for certain tests in
order to make sure, the correct permissions are tested.