### PR TITLE
fix(api): fix included identity showing private interests

### DIFF
--- a/api/mysagw/identity/serializers.py
+++ b/api/mysagw/identity/serializers.py
@@ -394,3 +394,10 @@ class MembershipSerializer(
             "comment",
             "inactive",
         )
+
+
+class MyMembershipsSerializer(MembershipSerializer):
+    included_serializers = {
+        "role": MembershipRoleSerializer,
+        "organisation": MyOrgsSerializer,
+    }

--- a/api/mysagw/identity/tests/test_membership_views.py
+++ b/api/mysagw/identity/tests/test_membership_views.py
@@ -272,8 +272,8 @@ def test_membership_create(
     "client,expected_status",
     [
         ("user", status.HTTP_403_FORBIDDEN),
-        ("staff", status.HTTP_405_METHOD_NOT_ALLOWED),
-        ("admin", status.HTTP_405_METHOD_NOT_ALLOWED),
+        ("staff", status.HTTP_403_FORBIDDEN),
+        ("admin", status.HTTP_403_FORBIDDEN),
     ],
     indirect=["client"],
 )
@@ -383,8 +383,8 @@ def test_membership_update(db, client, expected_status, membership_factory):
     "client,expected_status",
     [
         ("user", status.HTTP_403_FORBIDDEN),
-        ("staff", status.HTTP_405_METHOD_NOT_ALLOWED),
-        ("admin", status.HTTP_405_METHOD_NOT_ALLOWED),
+        ("staff", status.HTTP_403_FORBIDDEN),
+        ("admin", status.HTTP_403_FORBIDDEN),
     ],
     indirect=["client"],
 )

--- a/api/mysagw/identity/urls.py
+++ b/api/mysagw/identity/urls.py
@@ -14,6 +14,7 @@ r.register(r"interests", views.InterestViewSet)
 r.register(r"membership-roles", views.MembershipRoleViewSet)
 r.register(r"memberships", views.MembershipViewSet)
 r.register(r"my-orgs", views.MyOrgsViewSet, basename="my-orgs")
+r.register(r"my-memberships", views.MyMembershipViewSet, basename="my-memberships")
 
 urlpatterns = [
     url(

--- a/api/mysagw/identity/views.py
+++ b/api/mysagw/identity/views.py
@@ -292,3 +292,15 @@ class MembershipViewSet(views.ModelViewSet):
         super().perform_destroy(instance)
         instance.identity.modified_by_user = self.request.user.username
         instance.identity.save()
+
+
+class MyMembershipViewSet(
+    RetrieveModelMixin,
+    ListModelMixin,
+    GenericViewSet,
+):
+    serializer_class = serializers.MyMembershipsSerializer
+    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | (IsOwn & ReadOnly)),)
+
+    def get_queryset(self):
+        return self.request.user.identity.memberships.all()

--- a/api/mysagw/identity/views.py
+++ b/api/mysagw/identity/views.py
@@ -278,7 +278,7 @@ class MembershipRoleViewSet(views.ModelViewSet):
 class MembershipViewSet(views.ModelViewSet):
     serializer_class = serializers.MembershipSerializer
     queryset = models.Membership.objects.all()
-    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | (IsOwn & ReadOnly)),)
+    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | ReadOnly),)
     filterset_class = filters.MembershipFilterSet
 
     def get_queryset(self, *args, **kwargs):
@@ -300,7 +300,7 @@ class MyMembershipViewSet(
     GenericViewSet,
 ):
     serializer_class = serializers.MyMembershipsSerializer
-    permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | (IsOwn & ReadOnly)),)
+    permission_classes = (IsAuthenticated & (IsOwn & ReadOnly),)
 
     def get_queryset(self):
         return self.request.user.identity.memberships.all()

--- a/ember/app/adapters/application.js
+++ b/ember/app/adapters/application.js
@@ -31,4 +31,12 @@ export default class ApplicationAdapter extends JSONAPIAdapter.extend(
       snapshot.adapterOptions
     );
   }
+
+  urlForFindAll(modelName, snapshot) {
+    if (snapshot.adapterOptions?.customEndpoint) {
+      return `${this.buildURL()}/${snapshot.adapterOptions.customEndpoint}`;
+    }
+
+    return super.urlForFindAll(modelName, snapshot);
+  }
 }

--- a/ember/app/adapters/identity.js
+++ b/ember/app/adapters/identity.js
@@ -1,14 +1,6 @@
 import ApplicationAdapter from "./application";
 
 export default class IdentityAdapter extends ApplicationAdapter {
-  urlForFindAll(modelName, snapshot) {
-    if (snapshot.adapterOptions?.customEndpoint) {
-      return `${this.buildURL()}/${snapshot.adapterOptions.customEndpoint}`;
-    }
-
-    return super.urlForFindAll(modelName, snapshot);
-  }
-
   urlForFindRecord(id, modelName, snapshot) {
     if (snapshot.adapterOptions?.customEndpoint) {
       return `${this.buildURL()}/${

--- a/ember/app/ui/profile/index/controller.js
+++ b/ember/app/ui/profile/index/controller.js
@@ -26,9 +26,9 @@ export default class ProfileIndexController extends Controller.extend(
   @restartableTask
   *fetchMemberships() {
     try {
-      const memberships = yield this.store.query("membership", {
-        filter: { identity: this.model.id },
+      const memberships = yield this.store.findAll("membership", {
         include: "organisation,role",
+        adapterOptions: { customEndpoint: "my-memberships" },
       });
 
       return memberships;

--- a/ember/tests/unit/adapters/application-test.js
+++ b/ember/tests/unit/adapters/application-test.js
@@ -14,4 +14,19 @@ module("Unit | Adapter | application", function (hooks) {
       `${url}?include=bar`
     );
   });
+
+  test("urlForFindAll is correct", function (assert) {
+    const adapter = this.owner.lookup("adapter:application");
+
+    assert.strictEqual(
+      adapter.urlForFindAll("identity", {}),
+      "/api/v1/identities"
+    );
+    assert.strictEqual(
+      adapter.urlForFindAll("identity", {
+        adapterOptions: { customEndpoint: "my-orgs" },
+      }),
+      "/api/v1/my-orgs"
+    );
+  });
 });

--- a/ember/tests/unit/adapters/identity-test.js
+++ b/ember/tests/unit/adapters/identity-test.js
@@ -3,22 +3,6 @@ import { module, test } from "qunit";
 
 module("Unit | Adapter | identity", function (hooks) {
   setupTest(hooks);
-
-  test("urlForFindAll is correct", function (assert) {
-    const adapter = this.owner.lookup("adapter:identity");
-
-    assert.strictEqual(
-      adapter.urlForFindAll("identity", {}),
-      "/api/v1/identities"
-    );
-    assert.strictEqual(
-      adapter.urlForFindAll("identity", {
-        adapterOptions: { customEndpoint: "my-orgs" },
-      }),
-      "/api/v1/my-orgs"
-    );
-  });
-
   test("urlForFindRecord is correct", function (assert) {
     const adapter = this.owner.lookup("adapter:identity");
 


### PR DESCRIPTION
Use myorgs serializer for organisation includes on memberships, to
avoid including non public interests

Would this fix the bug or would I break something else with this? Can't remember the originally proposed solution