### PR TITLE
chore: temporarily disable frontend validation

### DIFF
--- a/ember/app/ui/components/submit-button/template.hbs
+++ b/ember/app/ui/components/submit-button/template.hbs
@@ -2,7 +2,7 @@
   @document={{@field.document}}
   @validateOnEnter={{false}}
   @onInvalid={{this.validationError}}
-  as |isValid validate|
+  {{!-- TODO: re-add `as |isValid validate|` --}}
 >
   <div {{in-viewport onEnter=(perform this.fetchWorkItem)}}></div>
   {{#if this.fetchWorkItem.isRunning}}
@@ -16,7 +16,7 @@
       @disabled={{not this.workItem}}
       @color="primary"
       @type="button"
-      @beforeMutate={{validate}}
+      @beforeMutate="false"  {{!-- TODO: set back to `{{validate}}` --}}
       @onSuccess={{this.transitionToCase}}
     />
   {{/if}}


### PR DESCRIPTION
This is needed, because frontend validation is broken right now.