### PR TITLE
chore: re-enable mailing

### DIFF
--- a/api/mysagw/case/email_texts.py
+++ b/api/mysagw/case/email_texts.py
@@ -1,56 +1,56 @@
-# SUBJECT_INVITE_EN = "You have been invited to an application on mySAGW"
-# BODY_INVITE_EN = """Hello {first_name} {last_name}
-#
-# You have been invited to an application on mySAGW:
-#
-# {link}
-# """
-#
-# SUBJECT_INVITE_DE = "Sie wurden zu einem Gesuch auf mySAGW eingeladen"
-# BODY_INVITE_DE = """Hallo {first_name} {last_name}
-#
-# Sie wurden zu einem Gesuch auf mySAGW eingeladen:
-#
-# {link}
-# """
-#
-# SUBJECT_INVITE_FR = "Vous avez été invité à déposer une demande sur mySAGW"
-# BODY_INVITE_FR = """Bonjour {first_name} {last_name}
-#
-# Vous avez été invité à déposer une demande sur mySAGW:
-#
-# {link}
-# """
-#
-#
-# EMAIL_INVITE_SUBJECTS = {
-#     "de": SUBJECT_INVITE_DE,
-#     "fr": SUBJECT_INVITE_FR,
-#     "en": SUBJECT_INVITE_EN,
-# }
-# EMAIL_INVITE_BODIES = {"de": BODY_INVITE_DE, "fr": BODY_INVITE_FR, "en": BODY_INVITE_EN}
-#
-#
-# EMAIL_SUBJECT_INVITE_REGISTER = "Sie wurden zu einem Gesuch auf mySAGW eingeladen"
-# EMAIL_BODY_INVITE_REGISTER = """DE:
-#
-# Hallo
-#
-# Bitte registrieren Sie sich auf {link}, um Zugang zu diesem Gesuch zu erhalten.
-#
-# ====================
-#
-# EN:
-#
-# Hello
-#
-# Please register on {link} for getting access to this application.
-#
-# ====================
-#
-# FR:
-#
-# Bonjour
-#
-# Veuillez vous inscrire sur {link} pour avoir accès à cette application.
-# """
+SUBJECT_INVITE_EN = "You have been invited to an application on mySAGW"
+BODY_INVITE_EN = """Hello {first_name} {last_name}
+
+You have been invited to an application on mySAGW:
+
+{link}
+"""
+
+SUBJECT_INVITE_DE = "Sie wurden zu einem Gesuch auf mySAGW eingeladen"
+BODY_INVITE_DE = """Hallo {first_name} {last_name}
+
+Sie wurden zu einem Gesuch auf mySAGW eingeladen:
+
+{link}
+"""
+
+SUBJECT_INVITE_FR = "Vous avez été invité à déposer une demande sur mySAGW"
+BODY_INVITE_FR = """Bonjour {first_name} {last_name}
+
+Vous avez été invité à déposer une demande sur mySAGW:
+
+{link}
+"""
+
+
+EMAIL_INVITE_SUBJECTS = {
+    "de": SUBJECT_INVITE_DE,
+    "fr": SUBJECT_INVITE_FR,
+    "en": SUBJECT_INVITE_EN,
+}
+EMAIL_INVITE_BODIES = {"de": BODY_INVITE_DE, "fr": BODY_INVITE_FR, "en": BODY_INVITE_EN}
+
+
+EMAIL_SUBJECT_INVITE_REGISTER = "Sie wurden zu einem Gesuch auf mySAGW eingeladen"
+EMAIL_BODY_INVITE_REGISTER = """DE:
+
+Hallo
+
+Bitte registrieren Sie sich auf {link}, um Zugang zu diesem Gesuch zu erhalten.
+
+====================
+
+EN:
+
+Hello
+
+Please register on {link} for getting access to this application.
+
+====================
+
+FR:
+
+Bonjour
+
+Veuillez vous inscrire sur {link} pour avoir accès à cette application.
+"""

--- a/api/mysagw/case/serializers.py
+++ b/api/mysagw/case/serializers.py
@@ -1,10 +1,10 @@
-# from django.conf import settings
-# from django.core.mail import send_mail
+from django.conf import settings
+from django.core.mail import send_mail
 from rest_framework.exceptions import ValidationError
 from rest_framework_json_api import serializers
 
 from ..identity.models import Identity
-from . import models
+from . import email_texts, models
 
 
 class CaseAccessSerializer(serializers.ModelSerializer):
@@ -49,25 +49,25 @@ class CaseAccessSerializer(serializers.ModelSerializer):
         if models.CaseAccess.objects.filter(case_id=instance.case_id).count() == 1:
             return instance
 
-        # subject = email_texts.EMAIL_SUBJECT_INVITE_REGISTER
-        # body = email_texts.EMAIL_BODY_INVITE_REGISTER.format(link=settings.SELF_URI)
-        # email = instance.email
-        #
-        # if instance.identity:
-        #     subject = email_texts.EMAIL_INVITE_SUBJECTS[instance.identity.language]
-        #     body = email_texts.EMAIL_INVITE_BODIES[instance.identity.language].format(
-        #         first_name=instance.identity.first_name or "",
-        #         last_name=instance.identity.last_name or "",
-        #         link=f"{settings.SELF_URI}/cases/{instance.case_id}",
-        #     )
-        #     email = instance.identity.email
-        #
-        # send_mail(
-        #     subject,
-        #     body,
-        #     settings.MAILING_SENDER,
-        #     [email],
-        #     fail_silently=True,
-        # )
+        subject = email_texts.EMAIL_SUBJECT_INVITE_REGISTER
+        body = email_texts.EMAIL_BODY_INVITE_REGISTER.format(link=settings.SELF_URI)
+        email = instance.email
+
+        if instance.identity:
+            subject = email_texts.EMAIL_INVITE_SUBJECTS[instance.identity.language]
+            body = email_texts.EMAIL_INVITE_BODIES[instance.identity.language].format(
+                first_name=instance.identity.first_name or "",
+                last_name=instance.identity.last_name or "",
+                link=f"{settings.SELF_URI}/cases/{instance.case_id}",
+            )
+            email = instance.identity.email
+
+        send_mail(
+            subject,
+            body,
+            settings.MAILING_SENDER,
+            [email],
+            fail_silently=True,
+        )
 
         return instance

--- a/api/mysagw/case/tests/test_case_views.py
+++ b/api/mysagw/case/tests/test_case_views.py
@@ -1,10 +1,11 @@
 from uuid import uuid4
 
 import pytest
+from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 
-from mysagw.case import models
+from mysagw.case import email_texts, models
 
 
 @pytest.mark.parametrize(
@@ -99,22 +100,22 @@ def test_case_create(
     else:
         assert case_access.email == "test@example.com"
         assert case_access.identity is None
-        # assert len(mailoutbox) == 1
-        # expected_body = email_texts.EMAIL_BODY_INVITE_REGISTER.format(
-        #     link=settings.SELF_URI,
-        # )
-        # assert mailoutbox[0].body == expected_body
+        assert len(mailoutbox) == 1
+        expected_body = email_texts.EMAIL_BODY_INVITE_REGISTER.format(
+            link=settings.SELF_URI,
+        )
+        assert mailoutbox[0].body == expected_body
 
-    # if identity_exists or has_access:
-    #     assert len(mailoutbox) == 1
-    #     expected_body = email_texts.EMAIL_INVITE_BODIES[
-    #         case_access.identity.language
-    #     ].format(
-    #         first_name=case_access.identity.first_name or "",
-    #         last_name=case_access.identity.last_name or "",
-    #         link=f"{settings.SELF_URI}/cases/{case_access.case_id}",
-    #     )
-    #     assert mailoutbox[0].body == expected_body
+    if identity_exists or has_access:
+        assert len(mailoutbox) == 1
+        expected_body = email_texts.EMAIL_INVITE_BODIES[
+            case_access.identity.language
+        ].format(
+            first_name=case_access.identity.first_name or "",
+            last_name=case_access.identity.last_name or "",
+            link=f"{settings.SELF_URI}/cases/{case_access.case_id}",
+        )
+        assert mailoutbox[0].body == expected_body
 
 
 def test_case_create_first(db, client, mailoutbox):

--- a/caluma/extensions/common.py
+++ b/caluma/extensions/common.py
@@ -24,15 +24,15 @@ def get_cases_for_user(user):
     return case_ids
 
 
-# def get_users_for_case(case):
-#     client = APIClient()
-#     token = client.get_admin_token()
-#     result = client.get(
-#         f"/case/accesses?filter%5BcaseId%5D={str(case.pk)}&include=identity",
-#         token=token,
-#     )
-#     users = []
-#     for include in result["included"]:
-#         users.append(include["attributes"])
-#
-#     return users
+def get_users_for_case(case):
+    client = APIClient()
+    token = client.get_admin_token()
+    result = client.get(
+        f"/case/accesses?filter%5BcaseId%5D={str(case.pk)}&include=identity",
+        token=token,
+    )
+    users = []
+    for include in result["included"]:
+        users.append(include["attributes"])
+
+    return users

--- a/caluma/extensions/email_texts.py
+++ b/caluma/extensions/email_texts.py
@@ -1,27 +1,27 @@
-# SUBJECT_EN = "There are news for you"
-# BODY_EN = """Hello {first_name} {last_name}
-#
-# There are news for you on mySAGW:
-#
-# {link}
-# """
-#
-# SUBJECT_DE = "Es gibt Neuigkeiten"
-# BODY_DE = """Hallo {first_name} {last_name}
-#
-# Es gibt Neuigkeiten für Sie auf mySAGW:
-#
-# {link}
-# """
-#
-# SUBJECT_FR = "Il y a des nouvelles"
-# BODY_FR = """Bonjour {first_name} {last_name}
-#
-# Il y a des nouvelles pour vous sur mySAGW:
-#
-# {link}
-# """
-#
-#
-# EMAIL_SUBJECTS = {"de": SUBJECT_DE, "fr": SUBJECT_FR, "en": SUBJECT_EN}
-# EMAIL_BODIES = {"de": BODY_DE, "fr": BODY_FR, "en": BODY_EN}
+SUBJECT_EN = "There are news for you"
+BODY_EN = """Hello {first_name} {last_name}
+
+There are news for you on mySAGW:
+
+{link}
+"""
+
+SUBJECT_DE = "Es gibt Neuigkeiten"
+BODY_DE = """Hallo {first_name} {last_name}
+
+Es gibt Neuigkeiten für Sie auf mySAGW:
+
+{link}
+"""
+
+SUBJECT_FR = "Il y a des nouvelles"
+BODY_FR = """Bonjour {first_name} {last_name}
+
+Il y a des nouvelles pour vous sur mySAGW:
+
+{link}
+"""
+
+
+EMAIL_SUBJECTS = {"de": SUBJECT_DE, "fr": SUBJECT_FR, "en": SUBJECT_EN}
+EMAIL_BODIES = {"de": BODY_DE, "fr": BODY_FR, "en": BODY_EN}

--- a/caluma/extensions/events/work_item.py
+++ b/caluma/extensions/events/work_item.py
@@ -1,4 +1,4 @@
-# from django.core.mail import send_mail
+from django.core.mail import send_mail
 from django.db import transaction
 
 from caluma.caluma_core.events import on
@@ -13,8 +13,8 @@ from caluma.caluma_workflow.events import (
     pre_complete_work_item,
 )
 
-# from .. import email_texts
-# from ..common import get_users_for_case
+from .. import email_texts
+from ..common import get_users_for_case
 from ..settings import settings
 
 
@@ -35,41 +35,41 @@ def set_assigned_user(sender, work_item, user, **kwargs):
     work_item.save()
 
 
-# @on(post_create_work_item, raise_exception=True)
-# def send_new_work_item_mail(sender, work_item, user, **kwargs):
-#     if work_item.task_id not in [
-#         "revise-document",
-#         "additional-data",
-#         "complete-document",
-#     ]:
-#         return
-#
-#     link = (
-#         f"{settings.SELF_URI}/cases/{work_item.case.pk}/work-items/{work_item.pk}/form"
-#     )
-#
-#     if work_item.task_id == "complete-document":
-#         link = f"{settings.SELF_URI}/cases/{work_item.case.pk}"
-#
-#     users = get_users_for_case(work_item.case)
-#
-#     for user in users:
-#         subject = email_texts.EMAIL_SUBJECTS[user["language"]]
-#         body = email_texts.EMAIL_BODIES[user["language"]]
-#
-#         body = body.format(
-#             first_name=user["first-name"] or "",
-#             last_name=user["last-name"] or "",
-#             link=link,
-#         )
-#
-#         send_mail(
-#             subject,
-#             body,
-#             settings.MAILING_SENDER,
-#             [user["email"]],
-#             fail_silently=True,
-#         )
+@on(post_create_work_item, raise_exception=True)
+def send_new_work_item_mail(sender, work_item, user, **kwargs):
+    if work_item.task_id not in [
+        "revise-document",
+        "additional-data",
+        "complete-document",
+    ]:
+        return
+
+    link = (
+        f"{settings.SELF_URI}/cases/{work_item.case.pk}/work-items/{work_item.pk}/form"
+    )
+
+    if work_item.task_id == "complete-document":
+        link = f"{settings.SELF_URI}/cases/{work_item.case.pk}"
+
+    users = get_users_for_case(work_item.case)
+
+    for user in users:
+        subject = email_texts.EMAIL_SUBJECTS[user["language"]]
+        body = email_texts.EMAIL_BODIES[user["language"]]
+
+        body = body.format(
+            first_name=user["first-name"] or "",
+            last_name=user["last-name"] or "",
+            link=link,
+        )
+
+        send_mail(
+            subject,
+            body,
+            settings.MAILING_SENDER,
+            [user["email"]],
+            fail_silently=True,
+        )
 
 
 @on(post_create_work_item, raise_exception=True)

--- a/caluma/extensions/tests/test_events.py
+++ b/caluma/extensions/tests/test_events.py
@@ -5,7 +5,7 @@ from caluma.caluma_form.models import Question
 from caluma.caluma_workflow.api import complete_work_item, skip_work_item, start_case
 from caluma.caluma_workflow.models import Workflow, WorkItem
 
-# from ..settings import settings
+from ..settings import settings
 
 
 def test_work_item_set_assigned_user(
@@ -245,22 +245,22 @@ def test_case_status(
     assert case.meta["status"] == "complete"
 
 
-# def test_send_new_work_item_mail(
-#     db, user, caluma_data, case_access_event_mock, document_review_case, mailoutbox
-# ):
-#     case = document_review_case
-#
-#     skip_work_item(case.work_items.get(task_id="submit-document"), user)
-#
-#     case.work_items.get(task_id="review-document").document.answers.create(
-#         question_id="review-document-decision",
-#         value="review-document-decision-reject",
-#     )
-#
-#     skip_work_item(case.work_items.get(task_id="review-document"), user)
-#     assert len(mailoutbox) == 1
-#     assert mailoutbox[0].from_email == settings.MAILING_SENDER
-#     assert mailoutbox[0].to == ["test-send@example.com"]
+def test_send_new_work_item_mail(
+    db, user, caluma_data, case_access_event_mock, document_review_case, mailoutbox
+):
+    case = document_review_case
+
+    skip_work_item(case.work_items.get(task_id="submit-document"), user)
+
+    case.work_items.get(task_id="review-document").document.answers.create(
+        question_id="review-document-decision",
+        value="review-document-decision-reject",
+    )
+
+    skip_work_item(case.work_items.get(task_id="review-document"), user)
+    assert len(mailoutbox) == 1
+    assert mailoutbox[0].from_email == settings.MAILING_SENDER
+    assert mailoutbox[0].to == ["test-send@example.com"]
 
 
 def test_access_control(


### PR DESCRIPTION
This commit re-enables sending of emails for new events and
invitations. Basically just reverting 466cf41100df53766cbfdab06d71209c9e211353

This is to be merged and deployed on Dec, 14th in the evening after 5 o'clock.