### PR TITLE
feat: enable caluma-analytics

### DIFF
--- a/ember/app/app.js
+++ b/ember/app/app.js
@@ -24,11 +24,11 @@ export default class App extends Application {
           ],
         },
       },
-      // "@projectcaluma/ember-analytics": {
-      //   dependencies: {
-      //     services: ["apollo", "notification", "intl", "router"],
-      //   },
-      // },
+      "@projectcaluma/ember-analytics": {
+        dependencies: {
+          services: ["apollo", "notification", "intl", "router"],
+        },
+      },
     };
   }
 }

--- a/ember/app/router.js
+++ b/ember/app/router.js
@@ -30,13 +30,11 @@ Router.map(function () {
         resetNamespace,
       });
     });
-    /* 
     this.mount("@projectcaluma/ember-analytics", {
       as: "analytics",
       path: "/analytics",
       resetNamespace,
     });
-    */
 
     // Caluma
     this.route("cases", { resetNamespace }, function () {

--- a/ember/app/styles/app.scss
+++ b/ember/app/styles/app.scss
@@ -5,7 +5,6 @@ $global-primary-background: $app-accent-color;
 @import "ember-uikit";
 @import "@projectcaluma/ember-form";
 @import "@projectcaluma/ember-form-builder";
-//@import "@projectcaluma/ember-analytics";
 @import "ember-power-select";
 
 @import "components/nav-bar";

--- a/ember/app/ui/components/nav-bar/template.hbs
+++ b/ember/app/ui/components/nav-bar/template.hbs
@@ -72,11 +72,9 @@
                 <li>
                   <LinkTo @route="form.configuration">{{t "components.nav-bar.form-configuration"}}</LinkTo>
                 </li>
-                {{!--
-                  <li>
-                    <LinkTo @route="analytics">{{t "components.nav-bar.analytics"}}</LinkTo>
-                  </li>
-                --}}
+                <li>
+                  <LinkTo @route="analytics">{{t "components.nav-bar.analytics"}}</LinkTo>
+                </li>
               {{/if}}
             </ul>
           </div>

--- a/ember/package.json
+++ b/ember/package.json
@@ -29,6 +29,7 @@
     "@ember/test-helpers": "^2.8.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@projectcaluma/ember-analytics": "https://gitpkg.now.sh/derrabauke/ember-caluma/packages/analytics?97c1e3fd",
     "@projectcaluma/ember-core": "^11.0.0-beta.7",
     "@projectcaluma/ember-form": "^11.0.0-beta.21",
     "@projectcaluma/ember-form-builder": "^11.0.0-beta.14",
@@ -109,10 +110,11 @@
   "resolutions": {
     "validated-changeset": "^1.3.2",
     "@embroider/macros": "^1.6.0",
-    "@apollo/client": "3.6.2"
+    "@apollo/client": "3.6.2",
+    "ember-resources": "5.0.2"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"

--- a/ember/yarn.lock
+++ b/ember/yarn.lock
@@ -21,7 +21,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@apollo/client@3.6.2", "@apollo/client@^3.5.10", "@apollo/client@^3.6.2", "@apollo/client@^3.6.6":
+"@apollo/client@3.6.2", "@apollo/client@^3.5.10", "@apollo/client@^3.6.2":
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.2.tgz#0418bfa6358dd117894c8af396706cfa2b186032"
   integrity sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==
@@ -3004,23 +3004,43 @@
     node-gyp "^9.0.0"
     read-package-json-fast "^2.0.3"
 
-"@projectcaluma/ember-core@^11.0.0-beta.7":
-  version "11.0.0-beta.7"
-  resolved "https://gitpkg.now.sh/derrabauke/ember-caluma/packages/core?4f1ba68d387a294d3fdbd40e0614ed4ad5159b72#ea255f2753dbf4abced4adf4279105d019851b3a"
+"@projectcaluma/ember-analytics@https://gitpkg.now.sh/derrabauke/ember-caluma/packages/analytics?97c1e3fd":
+  version "0.0.0"
+  resolved "https://gitpkg.now.sh/derrabauke/ember-caluma/packages/analytics?97c1e3fd#a2174e09d678b6900946fa55593186edba7d1757"
   dependencies:
-    "@apollo/client" "^3.6.6"
+    "@projectcaluma/ember-core" "^11.0.0-beta.6"
+    ember-apollo-client "^4.0.2"
+    ember-auto-import "^2.4.2"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.0.1"
+    ember-composable-helpers "^5.0.0"
+    ember-concurrency "^2.2.1"
+    ember-engines-router-service "^0.3.0"
+    ember-fetch "^8.0.4"
+    ember-intl "^5.7.0"
+    ember-power-select "5.0.4"
+    ember-resources "^5.0.1"
+    ember-uikit "^5.0.0"
+    ember-validated-form "^5.3.0"
+    graphql "^15.6.1"
+
+"@projectcaluma/ember-core@^11.0.0-beta.6", "@projectcaluma/ember-core@^11.0.0-beta.7":
+  version "11.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@projectcaluma/ember-core/-/ember-core-11.0.0-beta.7.tgz#74cc31997dbc4bc414f076adcae34707f0356b40"
+  integrity sha512-smT8q2WToS+EgBVpeV3wtMkW0Ysj+/elItvUTt+uY+pevYOr9b+pRDp88Eb7E70S+yijgDVss7qxZVmUnjY7QQ==
+  dependencies:
+    "@apollo/client" "^3.6.2"
     "@ember/string" "^3.0.0"
     "@glimmer/tracking" "^1.1.2"
     ember-apollo-client "^4.0.2"
-    ember-auto-import "^2.4.2"
+    ember-auto-import "^2.4.1"
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.0.1"
     ember-concurrency "^2.2.1"
     ember-fetch "^8.1.1"
     ember-inflector "^4.0.2"
     ember-intl "^5.7.2"
-    ember-resources "^4.8.2"
-    ember-uikit "^5.1.3"
+    ember-resources "^4.7.1"
     graphql "^15.8.0"
     graphql-tag "^2.12.6"
     jexl "^2.3.0"
@@ -8898,7 +8918,7 @@ ember-factory-for-polyfill@^1.3.1:
   dependencies:
     ember-cli-version-checker "^2.1.0"
 
-ember-fetch@^8.1.1:
+ember-fetch@^8.0.4, ember-fetch@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-8.1.1.tgz#d68d4a58529121a572ec09c39c6a3ad174c83a2e"
   integrity sha512-Xi1wNmPtVmfIoFH675AA0ELIdYUcoZ2p+6j9c8eDFjiGJiFesyp01bDtl5ryBI/1VPOByJLsDkT+4C11HixsJw==
@@ -9004,7 +9024,7 @@ ember-inflector@^3.0.1:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-intl@^5.7.2:
+ember-intl@^5.7.0, ember-intl@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ember-intl/-/ember-intl-5.7.2.tgz#76d933f974f041448b01247888bc3bcc9261e812"
   integrity sha512-gs17uY1ywzMaUpx1gxfBkFQYRTWTSa/zbkL13MVtffG9aBLP+998MibytZOUxIipMtLCm4sr/g6/1aaKRr9/+g==
@@ -9126,7 +9146,7 @@ ember-pikaday@^4.0.0:
     "@embroider/addon-shim" "^0.50.2"
     ember-modifier "^3.0.0"
 
-ember-power-select@^5.0.4:
+ember-power-select@5.0.4, ember-power-select@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-5.0.4.tgz#4af485fb7e1e1eca1bedd523892c82c672935dac"
   integrity sha512-FLVShZr3cYdLzymP+/0rXkfH5tD/FD958kynY86MWvn7ZyL2tXowlgVKY08n+PJHdo/vCrzqubRYckvXRSH6Bg==
@@ -9178,19 +9198,10 @@ ember-resolver@^8.0.3:
     ember-cli-version-checker "^5.1.2"
     resolve "^1.20.0"
 
-ember-resources@^4.7.1:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/ember-resources/-/ember-resources-4.10.0.tgz#8c05c39af2c04f4bf3713d5d585a946fead2d31f"
-  integrity sha512-xt/qJLLXUZ0FQZ3u0L4rw2rrV2b+7k9Apwr9X/zkD13bXB2pTpUcG7dlG7Ukb28Vvv83HlpOHEV67FM+os3YKw==
-  dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@embroider/addon-shim" "^1.2.0"
-    "@embroider/macros" "^1.2.0"
-
-ember-resources@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/ember-resources/-/ember-resources-4.8.2.tgz#4e86f0425882ec55a24c4b2fdbb2a24005bfcbb0"
-  integrity sha512-Ni4zkadhhPsIAGM974pK7gBaaajeFJmjrigKtPIFSaTdeCuNdDn99Cs0NVCZ22QSmh2L5/4tYQh8/nLHggZlaQ==
+ember-resources@5.0.2, ember-resources@^4.7.1, ember-resources@^4.8.2, ember-resources@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/ember-resources/-/ember-resources-5.0.2.tgz#c73fe2efd87100a2d9a7b3c99e5527146130338b"
+  integrity sha512-hqL0FAlXpA9ggYmxKTnpB3iYR/m8cuK9tzEuv+5QJfAunpWDKSpLTjY0HeQnjYcGEae46TbyfikTKgXMO8vKgQ==
   dependencies:
     "@babel/runtime" "^7.17.8"
     "@embroider/addon-shim" "^1.2.0"
@@ -11325,7 +11336,7 @@ graphql-tools@^4.0.8:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@^15.7.1, graphql@^15.8.0:
+graphql@^15.6.1, graphql@^15.7.1, graphql@^15.8.0:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==


### PR DESCRIPTION
This will enable `caluma-analytics` pre-release in mySAGW. Besides a little smoke-test of the integration into the host app, the referenced commit of `caluma-analytics` engine is **not** covered properly with tests yet. [This is the referenced commit](https://github.com/projectcaluma/ember-caluma/pull/1655/commits/97c1e3fd3cb14a8913017d76bfb6b2ed87685d00)